### PR TITLE
Fixed typo on page 68

### DIFF
--- a/parts/part_2/chapter_11_graph_games.tex
+++ b/parts/part_2/chapter_11_graph_games.tex
@@ -196,9 +196,9 @@ existence and uniqueness.
 Note that in this proof we used a procedure very similar to the one we used to
 find P- and N-positions.
 \begin{template}
-  \textbf{Steps necessary to find a Sparague--Grundy function} \\
+  \textbf{Steps necessary to find a Sprague--Grundy function} \\
 
-  Assume we are trying to construct a a Sparague--Grundy function $g$.
+  Assume we are trying to construct a a Sprague--Grundy function $g$.
   \begin{enumerate}
     \item Set $g(x) = 0$ for all terminal positions $x$.
     \item If $g(x)$ is not defined but $g(y)$ is defined for all $y \in N(x)$,

--- a/parts/part_3/chapter_13_sample_space.tex
+++ b/parts/part_3/chapter_13_sample_space.tex
@@ -125,7 +125,7 @@ Sometimes we are more interested in some function of the result of the
 experiment rather than the result itself. For example, Sasha may play Dungeons
 and Dragons and be interested in his chances to roill $7$ on two dices together.
 Let us formalize the question. Let $\Omega = \range{6}^2$ and $\Pr$ be a the
-uniform distribution on $\Omega$. Sasha is iterested in the probability of the
+uniform distribution on $\Omega$. Sasha is interested in the probability of the
 event $\set[x + y = 7]{(x, y) \in \range{6}^2}$.
 
 More generally, let $(\Omega, \Pr)$ be a finite discrete probability space. Then

--- a/parts/part_3/chapter_13_sample_space.tex
+++ b/parts/part_3/chapter_13_sample_space.tex
@@ -132,7 +132,7 @@ More generally, let $(\Omega, \Pr)$ be a finite discrete probability space. Then
 a function $\chi : \Omega \to \R$ is called a \emph{random variable} and 
 $\Pr(\chi = a)$ denotes $\Pr(\set[\chi(\omega) = a]{\omega \in \Omega})$. 
 
-In the example about Dangeons and Dragons, $\chi(x, y) = x + y$ and 
+In the example about Dungeons and Dragons, $\chi(x, y) = x + y$ and 
 we are interested in $\Pr(\chi = 7) = \Pr(\set{(1, 6), (2, 5), \dots, (6, 1)} =
 1/ 6$.
 \begin{exercise}


### PR DESCRIPTION
"Sprague" was misspelled as "Sparague" at 2 separate occurrences.